### PR TITLE
RSS-ECOMM-BUG-1: fix Eslint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,15 +3,11 @@ import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
+import vitestPlugin from 'eslint-plugin-vitest'
 
 export default tseslint.config(
   { ignores: ['dist'] },
   {
-    extends: [
-      js.configs.recommended,
-      ...tseslint.configs.strictTypeChecked,
-      'plugin:vitest/recommended',
-    ],
     files: ['**/*.{ts,tsx}'],
     languageOptions: {
       ecmaVersion: 2020,
@@ -19,6 +15,7 @@ export default tseslint.config(
         ...globals.browser,
         'vitest/globals': true,
       },
+      parser: tseslint.parser,
       parserOptions: {
         project: ['./tsconfig.node.json', './tsconfig.app.json'],
         tsconfigRootDir: import.meta.dirname,
@@ -27,9 +24,12 @@ export default tseslint.config(
     plugins: {
       'react-hooks': reactHooks,
       'react-refresh': reactRefresh,
-      vitest: require('eslint-plugin-vitest'),
+      vitest: vitestPlugin,
     },
     rules: {
+      ...js.configs.recommended.rules,
+      ...tseslint.configs.strictTypeChecked[0].rules,
+      ...reactHooks.configs.recommended.rules,
       ...reactHooks.configs.recommended.rules,
       'react-refresh/only-export-components': [
         'warn',

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@testing-library/react": "^16.3.0",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
+        "@typescript-eslint/parser": "^8.32.0",
         "@vitejs/plugin-react": "^4.4.1",
         "@vitest/ui": "^3.1.3",
         "eslint": "^9.26.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@testing-library/react": "^16.3.0",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
+    "@typescript-eslint/parser": "^8.32.0",
     "@vitejs/plugin-react": "^4.4.1",
     "@vitest/ui": "^3.1.3",
     "eslint": "^9.26.0",


### PR DESCRIPTION
## 📌 Summary

Fix Eslint config and add dependencies to avoid error after running the linting script.

## 🔗 Trello Task Link

[Trello Card](https://trello.com/c/i78Dvy7r)


## 🛠️ Proposed Changes

- `eslint.config.js` was updated to use ES module syntax (removed `require`)
- a parser that understands TypeScript (`@typescript-eslint/parser`) was added

## 💡 Rationale

Previously, running the linting script caused errors due to incompatible config syntax and missing TypeScript support. These changes modernize the ESLint config for use with ES modules and ensure correct parsing of TypeScript files.

## ✅ Checklist

- [x] Lint and tests pass (`npm run lint`, `npm run format`, `npm run test`)
- [x] This PR includes only one logical change (no mix of concerns)

