### PR TITLE
RSS-ECOMM-2_19: add direct navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-router-dom": "^7.6.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -5913,6 +5914,53 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.0.tgz",
+      "integrity": "sha512-GGufuHIVCJDbnIAXP3P9Sxzq3UUsddG3rrI3ut1q6m0FI6vxVBF3JoPQ38+W/blslLH4a5Yutp8drkEpXoddGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.0.tgz",
+      "integrity": "sha512-DYgm6RDEuKdopSyGOWZGtDfSm7Aofb8CCzgkliTjtu/eDuB0gcsv6qdFhhi8HdtmA+KHkt5MfZ5K2PdzjugYsA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -6248,6 +6296,12 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^7.6.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,12 +1,14 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
+import AppRouter from './routes/app-router'
 import App from './app.tsx'
 
 const rootElement = document.getElementById('root')
 if (rootElement) {
   createRoot(rootElement).render(
     <StrictMode>
+      <AppRouter />
       <App />
     </StrictMode>,
   )

--- a/src/pages/login-page.tsx
+++ b/src/pages/login-page.tsx
@@ -1,0 +1,8 @@
+const LoginPage = () => (
+    <section>
+      <h1>Login Page</h1>
+    </section>
+  );
+  
+  export default LoginPage;
+  

--- a/src/pages/main-page.tsx
+++ b/src/pages/main-page.tsx
@@ -1,0 +1,8 @@
+const MainPage = () => (
+    <section>
+      <h1>Main Page</h1>
+    </section>
+  );
+  
+  export default MainPage;
+  

--- a/src/pages/not-found-page.tsx
+++ b/src/pages/not-found-page.tsx
@@ -1,0 +1,8 @@
+const NotFoundPage = () => (
+    <section>
+      <h1>Not Found Page</h1>
+    </section>
+  );
+  
+  export default NotFoundPage;
+  

--- a/src/pages/registration-page.tsx
+++ b/src/pages/registration-page.tsx
@@ -1,0 +1,8 @@
+const RegistrationPage = () => (
+    <section>
+      <h1>Registration Page</h1>
+    </section>
+  );
+  
+  export default RegistrationPage;
+  

--- a/src/pages/tests/routing.test.tsx
+++ b/src/pages/tests/routing.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import MainPage from '../main-page';
+import LoginPage from '../login-page';
+import RegistrationPage from '../registration-page';
+import NotFoundPage from '../not-found-page';
+
+describe('Direct Navigation Routes', () => {
+  it('navigates to Main page via direct URL', () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route path="/" element={<MainPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.getByText(/Main/i)).toBeInTheDocument();
+  });
+
+  it('navigates to Login page via direct URL', () => {
+    render(
+      <MemoryRouter initialEntries={['/login']}>
+        <Routes>
+          <Route path="/login" element={<LoginPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.getByText(/Login/i)).toBeInTheDocument();
+  });
+
+  it('navigates to Registration page via direct URL', () => {
+    render(
+      <MemoryRouter initialEntries={['/register']}>
+        <Routes>
+          <Route path="/register" element={<RegistrationPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.getByText(/Registration/i)).toBeInTheDocument();
+  });
+});
+describe('Not Found Route', () => {
+  it('navigates to Not Found page via direct URL', () => {
+    render(
+      <MemoryRouter initialEntries={['/non-existent']}>
+        <Routes>
+          <Route path="*" element={<NotFoundPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.getByText(/Not Found/i)).toBeInTheDocument();
+  });
+});

--- a/src/routes/app-router.tsx
+++ b/src/routes/app-router.tsx
@@ -1,0 +1,18 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import MainPage from '../pages/main-page';
+import LoginPage from '../pages/login-page';
+import RegistrationPage from '../pages/registration-page';
+import NotFoundPage from '../pages/not-found-page';
+
+const AppRouter = () => (
+  <BrowserRouter>
+    <Routes>
+      <Route path="/" element={<MainPage />} />
+      <Route path="/login" element={<LoginPage />} />
+      <Route path="/register" element={<RegistrationPage />} />
+      <Route path="*" element={<NotFoundPage />} />
+    </Routes>
+  </BrowserRouter>
+);
+
+export default AppRouter;

--- a/src/tests/app.test.tsx
+++ b/src/tests/app.test.tsx
@@ -1,4 +1,3 @@
-import '@testing-library/jest-dom'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { test, expect } from 'vitest'
 

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
+    setupFiles: './src/tests/setup.ts',
     exclude: [...configDefaults.exclude, 'e2e/*'],
   },
 })


### PR DESCRIPTION
## 📌 Summary

Implement direct navigation for unauthorized users to the main, login, and registration pages

## 🔗 Trello Task Link

[Trello Card](https://trello.com/c/mPLzx4FR)


## 🛠️ Proposed Changes

- Implemented direct routing to `Main`, `Login`, and `Registration` pages for unauthorized users
- Set up `react-router-dom` routing structure in `app-router.tsx`
- Created page components for `Main`, `Login`, `Registration`, and `NotFound` pages
- Implemented fallback route (`path="*"`) to render a `NotFoundPage` for invalid URLs
- Added Vitest tests for direct navigation to these pages
- Configured Vitest with a setup file
- Updated `vite.config.ts` to include the test setup file

## 💡 Rationale

These changes ensure users can directly navigate to essential public pages (`/`, `/login`, `/register`) via the browser address bar.
They also handle invalid or unknown URLs gracefully by redirecting users to a custom `NotFoundPage`, improving the user experience and preventing broken or blank pages.
The setup also adds reliable test coverage using custom DOM matchers from `jest-dom`.

## ✅ Checklist

- [x] Code follows the project’s style guidelines
- [x] Lint and tests pass (`npm run lint`, `npm run format`, `npm run test`)
- [x] I’ve added/updated tests where applicable
- [x] This PR includes only one logical change (no mix of concerns)

