### PR TITLE
 RSS-ECOMM-2_14/set_default_address

### DIFF
--- a/src/features/auth/components/regForm.css
+++ b/src/features/auth/components/regForm.css
@@ -8,6 +8,10 @@ form-group {
   margin-bottom: 1rem;
 }
 
+.form-group label input[type='checkbox'] {
+  margin-right: 0.5rem;
+}
+
 label {
   display: block;
   margin-bottom: 0.3rem;

--- a/src/features/auth/components/regForm.tsx
+++ b/src/features/auth/components/regForm.tsx
@@ -45,6 +45,9 @@ export const RegForm = () => {
   const [message, setMessage] = useState('')
   const [errorMessage, setErrorMessage] = useState('')
 
+  const [defaultShipping, setDefaultShipping] = useState(false)
+  const [defaultBilling, setDefaultBilling] = useState(false)
+
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
   ) => {
@@ -89,21 +92,22 @@ export const RegForm = () => {
     const noErrors = validate(formData)
     if (!noErrors) return
 
+    const address = {
+      streetName: formData.street,
+      city: formData.city,
+      postalCode: formData.postalCode,
+      country: formData.country,
+    }
+
     const customerFormData = {
       email: formData.email,
       password: formData.password,
       firstName: formData.firstName,
       lastName: formData.lastName,
       dateOfBirth: formData.birthDate,
-      addresses: [
-        {
-          streetName: formData.street,
-          city: formData.city,
-          postalCode: formData.postalCode,
-          country: formData.country === 'United States' ? 'US' : 'CA',
-        },
-      ],
-      defaultShippingAddress: 0,
+      addresses: [ address],
+      defaultShippingAddress: defaultShipping ? 0 : undefined,
+      defaultBillingAddress: defaultBilling ? 0 : undefined,
     }
 
     try {
@@ -121,6 +125,8 @@ export const RegForm = () => {
         postalCode: '',
         country: '',
       })
+      setDefaultShipping(false)
+      setDefaultBilling(false)
       setErrors({})
       setHasSubmitted(false)
     } catch (error: any) {

--- a/src/features/auth/components/regForm.tsx
+++ b/src/features/auth/components/regForm.tsx
@@ -16,8 +16,13 @@ import type { CustomerType, FormDataType } from '../../../types/customer'
 
 const validCountries = ['United States', 'Canada']
 
+const countryNameToCode: Record<string, string> = {
+  Canada: 'CA',
+  'United States': 'US',
+}
+
 export const RegForm = () => {
-  const [formData, setFormData] = useState<FormDataType>({
+  const initialForm: FormDataType = {
     email: '',
     password: '',
     firstName: '',
@@ -31,14 +36,14 @@ export const RegForm = () => {
     billingCity: '',
     billingPostalCode: '',
     billingCountry: '',
-  })
+  }
 
+  const [formData, setFormData] = useState<FormDataType>(initialForm)
   const [errors, setErrors] = useState<{ [key: string]: string }>({})
   const [isButtonDisabled, setIsButtonDisabled] = useState(true)
   const [hasSubmitted, setHasSubmitted] = useState(false)
   const [message, setMessage] = useState('')
   const [errorMessage, setErrorMessage] = useState('')
-
   const [defaultShipping, setDefaultShipping] = useState(false)
   const [defaultBilling, setDefaultBilling] = useState(false)
   const [useSameAddress, setUseSameAddress] = useState(true)
@@ -46,28 +51,45 @@ export const RegForm = () => {
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
   ) => {
-    const updatedForm = { ...formData, [e.target.name]: e.target.value }
+    const { name, value } = e.target
+    const updatedForm = { ...formData, [name]: value }
     setFormData(updatedForm)
     if (hasSubmitted) validate(updatedForm)
   }
 
+  const validateBillingFields = (data: FormDataType) => {
+    const billingErrors: { [key: string]: string } = {}
+    if (!isValidStreet(data.billingStreet))
+      billingErrors.billingStreet = 'Billing street cannot be empty'
+    if (!isValidCity(data.billingCity))
+      billingErrors.billingCity = 'Invalid billing city'
+    if (!isValidPostalCode(data.billingPostalCode, data.billingCountry))
+      billingErrors.billingPostalCode = 'Invalid billing postal code'
+    if (!isValidCountry(data.billingCountry, validCountries))
+      billingErrors.billingCountry = 'Select a valid billing country'
+    return billingErrors
+  }
+
   const validate = (data: FormDataType) => {
-    const newErrors: typeof errors = {}
+    const newErrors: { [key: string]: string } = {}
 
     if (!isValidEmail(data.email)) newErrors.email = 'Invalid email format'
     if (!isValidPassword(data.password))
-      newErrors.password =
-        'Password must be at least 8 characters, include upper/lowercase, number and one special character'
+      newErrors.password = 'Password must be stronger'
     if (!isValidName(data.firstName)) newErrors.firstName = 'Invalid first name'
     if (!isValidName(data.lastName)) newErrors.lastName = 'Invalid last name'
     if (!isValidBirthDate(data.birthDate))
       newErrors.birthDate = 'You must be at least 13 years old'
     if (!isValidStreet(data.street)) newErrors.street = 'Street cannot be empty'
-    if (!isValidCity(data.city)) newErrors.city = 'Invalid city name'
+    if (!isValidCity(data.city)) newErrors.city = 'Invalid city'
     if (!isValidPostalCode(data.postalCode, data.country))
       newErrors.postalCode = 'Invalid postal code'
     if (!isValidCountry(data.country, validCountries))
       newErrors.country = 'Select a valid country'
+
+    if (!useSameAddress) {
+      Object.assign(newErrors, validateBillingFields(data))
+    }
 
     setErrors(newErrors)
     return Object.keys(newErrors).length === 0
@@ -102,15 +124,14 @@ export const RegForm = () => {
     setMessage('')
     setErrorMessage('')
 
-    const noErrors = validate(formData)
-    if (!noErrors) return
+    if (!validate(formData)) return
 
     const addresses = [
       {
         streetName: formData.street,
         city: formData.city,
         postalCode: formData.postalCode,
-        country: formData.country,
+        country: countryNameToCode[formData.country] || formData.country,
       },
     ]
 
@@ -119,15 +140,10 @@ export const RegForm = () => {
         streetName: formData.billingStreet,
         city: formData.billingCity,
         postalCode: formData.billingPostalCode,
-        country: formData.billingCountry,
+        country:
+          countryNameToCode[formData.billingCountry] || formData.billingCountry,
       })
     }
-
-    let defaultShippingIndex: number | undefined = undefined
-    let defaultBillingIndex: number | undefined = undefined
-
-    if (defaultShipping) defaultShippingIndex = 0
-    if (defaultBilling) defaultBillingIndex = useSameAddress ? 0 : 1
 
     const customerFormData: CustomerType = {
       email: formData.email,
@@ -137,7 +153,11 @@ export const RegForm = () => {
       dateOfBirth: formData.birthDate,
       addresses,
       defaultShippingAddress: defaultShipping ? 0 : undefined,
-      defaultBillingAddress: defaultBilling ? 0 : undefined,
+      defaultBillingAddress: defaultBilling
+        ? useSameAddress
+          ? 0
+          : 1
+        : undefined,
     }
 
     const sanitized = sanitizeCustomerDraft(customerFormData)
@@ -145,110 +165,114 @@ export const RegForm = () => {
       'Sanitized registration payload:',
       JSON.stringify(sanitized, null, 2),
     )
+
     try {
       const result = await authService.registerCustomer(
         sanitized as CustomerType,
       )
-      console.log('Success:', result)
-      setMessage(`Account created for ${result.customer.email}`)
-      setFormData({
-        email: '',
-        password: '',
-        firstName: '',
-        lastName: '',
-        birthDate: '',
-        street: '',
-        city: '',
-        postalCode: '',
-        country: '',
-        billingStreet: '',
-        billingCity: '',
-        billingPostalCode: '',
-        billingCountry: '',
-      })
+      setMessage(`✅ Account created for ${result.customer.email}`)
+      setFormData(initialForm)
       setDefaultShipping(false)
       setDefaultBilling(false)
       setErrors({})
       setHasSubmitted(false)
     } catch (error: any) {
-      console.error('Registration error:', error)
-
       const statusCode = error.statusCode || error.status || 500
+      const errorList = error.response?.data?.errors || []
       const fallbackMessage = error.message || 'Something went wrong'
-      const errorData = error.response?.data || error
-      const errorList = errorData.errors || []
 
-      console.error('🚨 Registration failed:', {
-        statusCode,
-        message,
-        errors: errorList,
-      })
-
-      let formattedMessage = ` Error ${statusCode}: ${message} `
+      let formattedMessage = `Error ${statusCode}: `
 
       switch (statusCode) {
-        case 400: {
-          if (errorList.length) {
-            formattedMessage +=
-              '\n' + errorList.map((e: any) => `• ${e.message}`).join('\n')
-          }
+        case 400:
+          formattedMessage +=
+            errorList.map((e: any) => `• ${e.message}`).join('\n') ||
+            fallbackMessage
           break
-        }
         case 401:
-          formattedMessage += '🔒 Unauthorized. Please log in again.'
+          formattedMessage += 'Unauthorized. Please log in again.'
           break
         case 403:
-          formattedMessage +=
-            '🚫 Access denied. You do not have permission to perform this action.'
+          formattedMessage += 'Access denied.'
           break
         case 409:
-          formattedMessage += '⚠️ An account with this email already exists.'
+          formattedMessage += 'An account with this email already exists.'
           break
         case 500:
         case 502:
         case 503:
-          formattedMessage += '⚠️ Server error. Please try again later.'
+          formattedMessage += 'Server error. Please try again later.'
           break
         default:
           formattedMessage += fallbackMessage
-          break
       }
 
       setErrorMessage(formattedMessage)
     }
   }
 
+  const renderInput = (
+    name: keyof FormDataType,
+    label: string,
+    type: string = 'text',
+  ) => (
+    <div className="form-group">
+      <label htmlFor={name}>{label}</label>
+      <input
+        type={type}
+        id={name}
+        name={name}
+        value={formData[name]}
+        onChange={handleChange}
+        className={hasSubmitted && errors[name] ? 'input-error' : ''}
+        aria-describedby={`${name}-error`}
+        aria-invalid={!!errors[name]}
+      />
+      {hasSubmitted && errors[name] && (
+        <span id={`${name}-error`} className="error-message">
+          ⚠️ {errors[name]}
+        </span>
+      )}
+    </div>
+  )
+
+  const renderSelect = (name: keyof FormDataType, label: string) => (
+    <div className="form-group">
+      <label htmlFor={name}>{label}</label>
+      <select
+        id={name}
+        name={name}
+        value={formData[name]}
+        onChange={handleChange}
+        className={hasSubmitted && errors[name] ? 'input-error' : ''}
+        aria-describedby={`${name}-error`}
+        aria-invalid={!!errors[name]}
+      >
+        <option value="">-- Select a country --</option>
+        {validCountries.map((country) => (
+          <option key={country} value={country}>
+            {country}
+          </option>
+        ))}
+      </select>
+      {hasSubmitted && errors[name] && (
+        <span id={`${name}-error`} className="error-message">
+          ⚠️ {errors[name]}
+        </span>
+      )}
+    </div>
+  )
+
   return (
     <form onSubmit={handleSubmit} className="reg-form">
       {message && <p className="success-message">{message}</p>}
       {errorMessage && <p className="error-message">{errorMessage}</p>}
 
-      {[
-        { name: 'email', type: 'email', label: 'Email' },
-        { name: 'password', type: 'password', label: 'Password' },
-        { name: 'firstName', type: 'text', label: 'First Name' },
-        { name: 'lastName', type: 'text', label: 'Last Name' },
-        { name: 'birthDate', type: 'date', label: 'Birth Date' },
-      ].map(({ name, type, label }) => (
-        <div key={name} className="form-group">
-          <label htmlFor={name}>{label}</label>
-          <input
-            type={type}
-            id={name}
-            name={name}
-            value={formData[name as keyof typeof formData]}
-            onChange={handleChange}
-            className={hasSubmitted && errors[name] ? 'input-error' : ''}
-            aria-describedby={`${name}-error`}
-            aria-invalid={!!errors[name]}
-          />
-          {hasSubmitted && errors[name] && (
-            <span id={`${name}-error`} className="error-message">
-              ⚠️ {errors[name]}
-            </span>
-          )}
-        </div>
-      ))}
+      {renderInput('email', 'Email', 'email')}
+      {renderInput('password', 'Password', 'password')}
+      {renderInput('firstName', 'First Name')}
+      {renderInput('lastName', 'Last Name')}
+      {renderInput('birthDate', 'Birth Date', 'date')}
 
       <div className="form-group checkbox-group">
         <label>
@@ -256,116 +280,47 @@ export const RegForm = () => {
             type="checkbox"
             checked={defaultShipping}
             onChange={() => setDefaultShipping(!defaultShipping)}
-          />
-          Set as default shipping address
+          />{' '}
+          Default Shipping
         </label>
-
         <label>
           <input
             type="checkbox"
             checked={defaultBilling}
             onChange={() => setDefaultBilling(!defaultBilling)}
-          />
-          Set as default billing address
+          />{' '}
+          Default Billing
         </label>
         <label>
           <input
             type="checkbox"
             checked={useSameAddress}
             onChange={() => setUseSameAddress(!useSameAddress)}
-          />
-          Use the same address for billing and shipping
+          />{' '}
+          Use same address
         </label>
       </div>
+
       <h3>Shipping Address</h3>
-      {[
-        { name: 'street', type: 'text', label: 'Street' },
-        { name: 'city', type: 'text', label: 'City' },
-        { name: 'postalCode', type: 'text', label: 'Postal Code' },
-      ].map(({ name, type, label }) => (
-        <div key={name} className="form-group">
-          <label htmlFor={name}>{label}</label>
-          <input
-            type={type}
-            id={name}
-            name={name}
-            value={formData[name as keyof typeof formData]}
-            onChange={handleChange}
-            className={hasSubmitted && errors[name] ? 'input-error' : ''}
-            aria-describedby={`${name}-error`}
-            aria-invalid={!!errors[name]}
-          />
-          {hasSubmitted && errors[name] && (
-            <span id={`${name}-error`} className="error-message">
-              ⚠️ {errors[name]}
-            </span>
-          )}
-        </div>
-      ))}
-      <div className="form-group">
-        <label htmlFor="country">Country</label>
-        <select
-          id="country"
-          name="country"
-          value={formData.country}
-          onChange={handleChange}
-          className={hasSubmitted && errors.country ? 'input-error' : ''}
-          aria-describedby="country-error"
-          aria-invalid={!!errors.country}
-        >
-          <option value="">-- Select a country --</option>
-          {validCountries.map((country) => (
-            <option key={country} value={country}>
-              {country}
-            </option>
-          ))}
-        </select>
-        {hasSubmitted && errors.country && (
-          <span id="country-error" className="error-message">
-            ⚠️ {errors.country}
-          </span>
-        )}
-      </div>
+      {renderInput('street', 'Street')}
+      {renderInput('city', 'City')}
+      {renderInput('postalCode', 'Postal Code')}
+      {renderSelect('country', 'Country')}
 
       {!useSameAddress && (
         <>
           <h3>Billing Address</h3>
-          {[
-            { name: 'billingStreet', type: 'text', label: 'Street' },
-            { name: 'billingCity', type: 'text', label: 'City' },
-            { name: 'billingPostalCode', type: 'text', label: 'Postal Code' },
-          ].map(({ name, type, label }) => (
-            <div key={name} className="form-group">
-              <label htmlFor={name}>{label}</label>
-              <input
-                type={type}
-                id={name}
-                name={name}
-                value={formData[name as keyof typeof formData]}
-                onChange={handleChange}
-              />
-            </div>
-          ))}
-          <div className="form-group">
-            <label htmlFor="billingCountry">Country</label>
-            <select
-              id="billingCountry"
-              name="billingCountry"
-              value={formData.billingCountry}
-              onChange={handleChange}
-            >
-              <option value="">-- Select a country --</option>
-              {validCountries.map((country) => (
-                <option key={country} value={country}>
-                  {country}
-                </option>
-              ))}
-            </select>
-          </div>
+          {renderInput('billingStreet', 'Street')}
+          {renderInput('billingCity', 'City')}
+          {renderInput('billingPostalCode', 'Postal Code')}
+          {renderSelect('billingCountry', 'Billing Country')}
         </>
       )}
 
-      <button type="submit" disabled={isButtonDisabled}>
+      <button
+        type="submit"
+        disabled={isButtonDisabled || Object.keys(errors).length > 0}
+      >
         Register
       </button>
     </form>

--- a/src/features/auth/components/regForm.tsx
+++ b/src/features/auth/components/regForm.tsx
@@ -105,7 +105,7 @@ export const RegForm = () => {
       firstName: formData.firstName,
       lastName: formData.lastName,
       dateOfBirth: formData.birthDate,
-      addresses: [ address],
+      addresses: [address],
       defaultShippingAddress: defaultShipping ? 0 : undefined,
       defaultBillingAddress: defaultBilling ? 0 : undefined,
     }
@@ -188,6 +188,47 @@ export const RegForm = () => {
         { name: 'firstName', type: 'text', label: 'First Name' },
         { name: 'lastName', type: 'text', label: 'Last Name' },
         { name: 'birthDate', type: 'date', label: 'Birth Date' },
+      ].map(({ name, type, label }) => (
+        <div key={name} className="form-group">
+          <label htmlFor={name}>{label}</label>
+          <input
+            type={type}
+            id={name}
+            name={name}
+            value={formData[name as keyof typeof formData]}
+            onChange={handleChange}
+            className={hasSubmitted && errors[name] ? 'input-error' : ''}
+            aria-describedby={`${name}-error`}
+            aria-invalid={!!errors[name]}
+          />
+          {hasSubmitted && errors[name] && (
+            <span id={`${name}-error`} className="error-message">
+              ⚠️ {errors[name]}
+            </span>
+          )}
+        </div>
+      ))}
+
+      <div className="form-group checkbox-group">
+        <label>
+          <input
+            type="checkbox"
+            checked={defaultShipping}
+            onChange={() => setDefaultShipping(!defaultShipping)}
+          />
+          Set as default shipping address
+        </label>
+
+        <label>
+          <input
+            type="checkbox"
+            checked={defaultBilling}
+            onChange={() => setDefaultBilling(!defaultBilling)}
+          />
+          Set as default billing address
+        </label>
+      </div>
+      {[
         { name: 'street', type: 'text', label: 'Street' },
         { name: 'city', type: 'text', label: 'City' },
         { name: 'postalCode', type: 'text', label: 'Postal Code' },
@@ -211,7 +252,6 @@ export const RegForm = () => {
           )}
         </div>
       ))}
-
       <div className="form-group">
         <label htmlFor="country">Country</label>
         <select

--- a/src/features/auth/components/regForm.tsx
+++ b/src/features/auth/components/regForm.tsx
@@ -75,7 +75,7 @@ export const RegForm = () => {
 
     if (!isValidEmail(data.email)) newErrors.email = 'Invalid email format'
     if (!isValidPassword(data.password))
-      newErrors.password = 'Password must be stronger'
+      newErrors.password = 'Password must be at least 8 characters, include upper/lowercase, number and one special character'
     if (!isValidName(data.firstName)) newErrors.firstName = 'Invalid first name'
     if (!isValidName(data.lastName)) newErrors.lastName = 'Invalid last name'
     if (!isValidBirthDate(data.birthDate))

--- a/src/features/auth/components/regForm.tsx
+++ b/src/features/auth/components/regForm.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import * as authService from '../services/authService'
+import { sanitizeCustomerDraft } from '../services/authService'
 import {
   isValidEmail,
   isValidPassword,
@@ -11,20 +12,9 @@ import {
   isValidCountry,
 } from '../../../utils/validators'
 import './regForm.css'
+import type { CustomerType, FormDataType } from '../../../types/customer'
 
 const validCountries = ['United States', 'Canada']
-
-type FormDataType = {
-  email: string
-  password: string
-  firstName: string
-  lastName: string
-  birthDate: string
-  street: string
-  city: string
-  postalCode: string
-  country: string
-}
 
 export const RegForm = () => {
   const [formData, setFormData] = useState<FormDataType>({
@@ -37,6 +27,10 @@ export const RegForm = () => {
     city: '',
     postalCode: '',
     country: '',
+    billingStreet: '',
+    billingCity: '',
+    billingPostalCode: '',
+    billingCountry: '',
   })
 
   const [errors, setErrors] = useState<{ [key: string]: string }>({})
@@ -47,6 +41,7 @@ export const RegForm = () => {
 
   const [defaultShipping, setDefaultShipping] = useState(false)
   const [defaultBilling, setDefaultBilling] = useState(false)
+  const [useSameAddress, setUseSameAddress] = useState(true)
 
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
@@ -83,6 +78,24 @@ export const RegForm = () => {
     setIsButtonDisabled(!allFilled)
   }, [formData])
 
+  useEffect(() => {
+    if (useSameAddress) {
+      setFormData((prev) => ({
+        ...prev,
+        billingStreet: prev.street,
+        billingCity: prev.city,
+        billingPostalCode: prev.postalCode,
+        billingCountry: prev.country,
+      }))
+    }
+  }, [
+    formData.street,
+    formData.city,
+    formData.postalCode,
+    formData.country,
+    useSameAddress,
+  ])
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setHasSubmitted(true)
@@ -92,26 +105,50 @@ export const RegForm = () => {
     const noErrors = validate(formData)
     if (!noErrors) return
 
-    const address = {
-      streetName: formData.street,
-      city: formData.city,
-      postalCode: formData.postalCode,
-      country: formData.country,
+    const addresses = [
+      {
+        streetName: formData.street,
+        city: formData.city,
+        postalCode: formData.postalCode,
+        country: formData.country,
+      },
+    ]
+
+    if (!useSameAddress) {
+      addresses.push({
+        streetName: formData.billingStreet,
+        city: formData.billingCity,
+        postalCode: formData.billingPostalCode,
+        country: formData.billingCountry,
+      })
     }
 
-    const customerFormData = {
+    let defaultShippingIndex: number | undefined = undefined
+    let defaultBillingIndex: number | undefined = undefined
+
+    if (defaultShipping) defaultShippingIndex = 0
+    if (defaultBilling) defaultBillingIndex = useSameAddress ? 0 : 1
+
+    const customerFormData: CustomerType = {
       email: formData.email,
       password: formData.password,
       firstName: formData.firstName,
       lastName: formData.lastName,
       dateOfBirth: formData.birthDate,
-      addresses: [address],
+      addresses,
       defaultShippingAddress: defaultShipping ? 0 : undefined,
       defaultBillingAddress: defaultBilling ? 0 : undefined,
     }
 
+    const sanitized = sanitizeCustomerDraft(customerFormData)
+    console.log(
+      'Sanitized registration payload:',
+      JSON.stringify(sanitized, null, 2),
+    )
     try {
-      const result = await authService.registerCustomer(customerFormData)
+      const result = await authService.registerCustomer(
+        sanitized as CustomerType,
+      )
       console.log('Success:', result)
       setMessage(`Account created for ${result.customer.email}`)
       setFormData({
@@ -124,6 +161,10 @@ export const RegForm = () => {
         city: '',
         postalCode: '',
         country: '',
+        billingStreet: '',
+        billingCity: '',
+        billingPostalCode: '',
+        billingCountry: '',
       })
       setDefaultShipping(false)
       setDefaultBilling(false)
@@ -227,7 +268,16 @@ export const RegForm = () => {
           />
           Set as default billing address
         </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={useSameAddress}
+            onChange={() => setUseSameAddress(!useSameAddress)}
+          />
+          Use the same address for billing and shipping
+        </label>
       </div>
+      <h3>Shipping Address</h3>
       {[
         { name: 'street', type: 'text', label: 'Street' },
         { name: 'city', type: 'text', label: 'City' },
@@ -276,6 +326,44 @@ export const RegForm = () => {
           </span>
         )}
       </div>
+
+      {!useSameAddress && (
+        <>
+          <h3>Billing Address</h3>
+          {[
+            { name: 'billingStreet', type: 'text', label: 'Street' },
+            { name: 'billingCity', type: 'text', label: 'City' },
+            { name: 'billingPostalCode', type: 'text', label: 'Postal Code' },
+          ].map(({ name, type, label }) => (
+            <div key={name} className="form-group">
+              <label htmlFor={name}>{label}</label>
+              <input
+                type={type}
+                id={name}
+                name={name}
+                value={formData[name as keyof typeof formData]}
+                onChange={handleChange}
+              />
+            </div>
+          ))}
+          <div className="form-group">
+            <label htmlFor="billingCountry">Country</label>
+            <select
+              id="billingCountry"
+              name="billingCountry"
+              value={formData.billingCountry}
+              onChange={handleChange}
+            >
+              <option value="">-- Select a country --</option>
+              {validCountries.map((country) => (
+                <option key={country} value={country}>
+                  {country}
+                </option>
+              ))}
+            </select>
+          </div>
+        </>
+      )}
 
       <button type="submit" disabled={isButtonDisabled}>
         Register

--- a/src/features/auth/services/authService.ts
+++ b/src/features/auth/services/authService.ts
@@ -32,15 +32,33 @@ async function getClientAccessToken() {
   return customerData.access_token
 }
 
+export function sanitizeCustomerDraft(
+  draft: CustomerType,
+): Record<string, unknown> {
+  const cleaned: Record<string, unknown> = {}
+
+  for (const key in draft) {
+    const value = (draft as any)[key]
+    if (value !== undefined && value !== null) {
+      cleaned[key] = value
+    }
+  }
+
+  return cleaned
+}
+
 export async function registerCustomer(customerDraft: CustomerType) {
   const token = await getClientAccessToken()
+
+  const sanitized = sanitizeCustomerDraft(customerDraft)
+
   const response = await fetch(API_SIGNUP_URL, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${token}`,
     },
-    body: JSON.stringify(customerDraft),
+    body: JSON.stringify(sanitized),
   })
 
   if (!response.ok) {

--- a/src/types/customer.ts
+++ b/src/types/customer.ts
@@ -9,8 +9,8 @@ export type CustomerType = {
 }
 
 export type Address = {
-  streetName: string;
-  city: string;
-  postalCode: string;
-  country: string;
-};
+  streetName: string
+  city: string
+  postalCode: string
+  country: string
+}

--- a/src/types/customer.ts
+++ b/src/types/customer.ts
@@ -7,3 +7,10 @@ export type CustomerType = {
   addresses?: any[]
   defaultShippingAddress?: number
 }
+
+export type Address = {
+  streetName: string;
+  city: string;
+  postalCode: string;
+  country: string;
+};

--- a/src/types/customer.ts
+++ b/src/types/customer.ts
@@ -4,8 +4,9 @@ export type CustomerType = {
   firstName?: string
   lastName?: string
   dateOfBirth?: string
-  addresses?: any[]
+  addresses?: Address[]
   defaultShippingAddress?: number
+  defaultBillingAddress?: number
 }
 
 export type Address = {
@@ -13,4 +14,20 @@ export type Address = {
   city: string
   postalCode: string
   country: string
+}
+
+export type FormDataType = {
+  email: string
+  password: string
+  firstName: string
+  lastName: string
+  birthDate: string
+  street: string
+  city: string
+  postalCode: string
+  country: string
+  billingStreet: string
+  billingCity: string
+  billingPostalCode: string
+  billingCountry: string
 }


### PR DESCRIPTION
## 📌 Summary
Allow users to set a default address during registration
Enable users to select different billing and shipping addresses during registration
<!-- Provide a brief summary of the changes made in this PR -->

## 🔗 Trello Task Link

<!-- Add a link to the Trello card this PR addresses -->

[Trello Card](https://trello.com/c/k69IlSXG/39-rss-ecomm-214-allow-users-to-set-a-default-address-during-registration)

## 🛠️ Proposed Changes

<!-- List the main changes made -->

-Include a checkbox or a toggle switch next to the address input fields during the registration process. The checkbox could read 'Set as default address' to make it clear for the user. 
- In the backend, ensure the process of setting a default address occurs simultaneously with the creation of the user account. When a user sets an address as the default, use the commercetools API to store this information by making a POST request to the customers endpoint with the defaultShippingAddress and/or defaultBillingAddress properties set in the request body.
-In the registration form, include separate input fields for billing and shipping addresses. 
-Additionally, provide a checkbox that users can tick if they want to use the same address for both billing and shipping. If checked, the application should copy the values from one set of fields to the other. 
-When the user submits the form, send a request to the commercetools API to create a new customer. Include the billing and shipping address information in the request body, as described in the [commercetools CustomerDraft documentation](https://docs.commercetools.com/api/projects/customers#ctp:api:type:CustomerDraft).
-Provide clear labeling next to the checkbox or toggle switch indicating that this will set the address as the default for future transactions. 
-If possible, visually separate the default address selection from other fields to draw the user's attention
-Clearly label the input fields for billing and shipping addresses. 🏷️
-Place the checkbox for using the same address for both purposes in a prominent location on the form. 

## 💡 Rationale

<!-- Explain the reason for the changes and the problem it solves -->

## ✅ Checklist

- [ ] Code follows the project’s style guidelines
- [ ] Lint and tests pass (`npm run lint`, `npm run format`, `npm run test`)
- [ ] I’ve added/updated relevant documentation
- [ ] I’ve added/updated tests where applicable
- [ ] This PR includes only one logical change (no mix of concerns)
