### PR TITLE
RSS-ECOMM-2_07:/Handle_Authentication_Token

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,16 +1,7 @@
-import { useEffect } from 'react'
-import { useAppDispatch } from './store/hooks'
-import { verifyTokenAsync } from './store/slices/auth-slice'
 import AppRouter from './routes/app-router'
 import './app.css'
 
 function App() {
-  const dispatch = useAppDispatch()
-
-  useEffect(() => {
-    dispatch(verifyTokenAsync())
-  }, [dispatch])
-  
   return (
     <>
       <AppRouter />

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,7 +1,16 @@
-import './app.css'
+import { useEffect } from 'react'
+import { useAppDispatch } from './store/hooks'
+import { verifyTokenAsync } from './store/slices/auth-slice'
 import AppRouter from './routes/app-router'
+import './app.css'
 
 function App() {
+  const dispatch = useAppDispatch()
+
+  useEffect(() => {
+    dispatch(verifyTokenAsync())
+  }, [dispatch])
+  
   return (
     <>
       <AppRouter />

--- a/src/components/tests/navigation.test.tsx
+++ b/src/components/tests/navigation.test.tsx
@@ -9,13 +9,13 @@ import authReducer from '../../store/slices/auth-slice'
 const renderWithStore = (isLoggedIn: boolean) => {
   const store = configureStore({
     reducer: { auth: authReducer },
-    preloadedState: { 
-      auth:  {
-        isLoggedIn ,
+    preloadedState: {
+      auth: {
+        isLoggedIn,
         customer: null,
         token: isLoggedIn ? 'fake-token' : null,
         status: 'idle' as 'idle',
-        error:  null
+        error: null,
       },
     },
   })

--- a/src/components/tests/navigation.test.tsx
+++ b/src/components/tests/navigation.test.tsx
@@ -9,10 +9,13 @@ import authReducer from '../../store/slices/auth-slice'
 const renderWithStore = (isLoggedIn: boolean) => {
   const store = configureStore({
     reducer: { auth: authReducer },
-    preloadedState: {
-      auth: {
-        isLoggedIn,
+    preloadedState: { 
+      auth:  {
+        isLoggedIn ,
         customer: null,
+        token: isLoggedIn ? 'fake-token' : null,
+        status: 'idle' as 'idle',
+        error:  null
       },
     },
   })

--- a/src/features/auth/components/loginForm.tsx
+++ b/src/features/auth/components/loginForm.tsx
@@ -60,6 +60,7 @@ export const LoginForm = () => {
         <input
           type="email"
           id="email"
+          name="email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           className={hasValidated && errors.email ? 'input-error' : ''}

--- a/src/features/auth/components/loginForm.tsx
+++ b/src/features/auth/components/loginForm.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react'
 import { isValidEmail, isValidPassword } from '../../../utils/validators'
-import { login } from '../../../store/slices/auth-slice'
+import { loginAsync } from '../../../store/slices/auth-slice'
 import { useAppDispatch, useAppSelector } from '../../../store/hooks'
 import { getCustomerData, loginWithPassword } from '../services/authService'
-import { saveAuthState } from '../../../store/local-storage'
+import { saveAuthState, saveToken } from '../../../store/local-storage'
 import './regForm.css'
 
 export const LoginForm = () => {
@@ -38,21 +38,8 @@ export const LoginForm = () => {
 
     if (validate()) {
       try {
-        const tokenData = await loginWithPassword(email, password)
-        const customer = await getCustomerData(tokenData.access_token)
-
-        const payload = {
-          customer,
-          token: tokenData.access_token,
-        }
-
-        dispatch(login(payload))
-        saveAuthState({
-          isLoggedIn: true,
-          customer,
-          token: tokenData.access_token,
-        })
-        console.log('Customer data:', customer)
+        const result = await dispatch(loginAsync({ email, password })).unwrap()
+        console.log('Customer data:', result.customer)
       } catch (error: any) {
         setLoginError(error.message || 'Login failed')
       }

--- a/src/features/auth/components/loginForm.tsx
+++ b/src/features/auth/components/loginForm.tsx
@@ -1,9 +1,12 @@
 import React, { useState } from 'react'
 import { isValidEmail, isValidPassword } from '../../../utils/validators'
-import { loginAsync } from '../../../store/slices/auth-slice'
+import {
+  loginStarted,
+  login,
+  loginFailed,
+} from '../../../store/slices/auth-slice'
 import { useAppDispatch, useAppSelector } from '../../../store/hooks'
-import { getCustomerData, loginWithPassword } from '../services/authService'
-import { saveAuthState, saveToken } from '../../../store/local-storage'
+import { loginUser } from '../services/authService'
 import './regForm.css'
 
 export const LoginForm = () => {
@@ -36,13 +39,17 @@ export const LoginForm = () => {
     setHasValidated(true)
     setLoginError('')
 
-    if (validate()) {
-      try {
-        const result = await dispatch(loginAsync({ email, password })).unwrap()
-        console.log('Customer data:', result.customer)
-      } catch (error: any) {
-        setLoginError(error.message || 'Login failed')
-      }
+    if (!validate()) return
+    dispatch(loginStarted())
+
+    try {
+      const result = await loginUser(email, password)
+      dispatch(login(result))
+      console.log('Customer data:', result.customer)
+    } catch (error: any) {
+      const message = error.message || 'Login failed'
+      dispatch(loginFailed(message))
+      setLoginError(message)
     }
   }
 
@@ -53,7 +60,6 @@ export const LoginForm = () => {
         <input
           type="email"
           id="email"
-          name="email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           className={hasValidated && errors.email ? 'input-error' : ''}

--- a/src/features/auth/components/loginForm.tsx
+++ b/src/features/auth/components/loginForm.tsx
@@ -3,6 +3,7 @@ import { isValidEmail, isValidPassword } from '../../../utils/validators'
 import { login } from '../../../store/slices/auth-slice'
 import { useAppDispatch, useAppSelector } from '../../../store/hooks'
 import { getCustomerData, loginWithPassword } from '../services/authService'
+import { saveAuthState } from '../../../store/local-storage'
 import './regForm.css'
 
 export const LoginForm = () => {
@@ -37,9 +38,20 @@ export const LoginForm = () => {
 
     if (validate()) {
       try {
-        const tokens = await loginWithPassword(email, password)
-        const customer = await getCustomerData(tokens.access_token)
-        dispatch(login(customer))
+        const tokenData = await loginWithPassword(email, password)
+        const customer = await getCustomerData(tokenData.access_token)
+
+        const payload = {
+          customer,
+          token: tokenData.access_token,
+        }
+
+        dispatch(login(payload))
+        saveAuthState({
+          isLoggedIn: true,
+          customer,
+          token: tokenData.access_token,
+        })
         console.log('Customer data:', customer)
       } catch (error: any) {
         setLoginError(error.message || 'Login failed')

--- a/src/features/auth/components/regForm.tsx
+++ b/src/features/auth/components/regForm.tsx
@@ -75,7 +75,8 @@ export const RegForm = () => {
 
     if (!isValidEmail(data.email)) newErrors.email = 'Invalid email format'
     if (!isValidPassword(data.password))
-      newErrors.password = 'Password must be at least 8 characters, include upper/lowercase, number and one special character'
+      newErrors.password =
+        'Password must be at least 8 characters, include upper/lowercase, number and one special character'
     if (!isValidName(data.firstName)) newErrors.firstName = 'Invalid first name'
     if (!isValidName(data.lastName)) newErrors.lastName = 'Invalid last name'
     if (!isValidBirthDate(data.birthDate))

--- a/src/features/auth/components/regForm.tsx
+++ b/src/features/auth/components/regForm.tsx
@@ -179,6 +179,8 @@ export const RegForm = () => {
       dispatch(login(result.customer))
       console.log('Registration successful:', result)
 
+      setMessage(`Account created for ${result.customer.email}`)
+
       setFormData(initialForm)
       setDefaultShipping(false)
       setDefaultBilling(false)

--- a/src/features/auth/components/regForm.tsx
+++ b/src/features/auth/components/regForm.tsx
@@ -179,8 +179,6 @@ export const RegForm = () => {
       dispatch(login(result.customer))
       console.log('Registration successful:', result)
 
-      setMessage(`Account created for ${result.customer.email}`)
-
       setFormData(initialForm)
       setDefaultShipping(false)
       setDefaultBilling(false)

--- a/src/features/auth/components/tests/regForm.test.tsx
+++ b/src/features/auth/components/tests/regForm.test.tsx
@@ -1,10 +1,9 @@
 import React from 'react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { configureStore } from '@reduxjs/toolkit'
 import { RegForm } from '../regForm'
-import { store } from '../../../../store'
 import * as authService from '../../services/authService'
 import authReducer from '../../../../store/slices/auth-slice'
 
@@ -18,9 +17,6 @@ function renderWithStore(ui: React.ReactElement) {
 }
 
 describe('Registration Form', () => {
-  const renderWithProvider = (ui: React.ReactElement) => {
-    return render(<Provider store={store}>{ui}</Provider>)
-  }
 
   it('renders all required input fields', () => {
     renderWithStore(<RegForm />)

--- a/src/features/auth/components/tests/regForm.test.tsx
+++ b/src/features/auth/components/tests/regForm.test.tsx
@@ -17,7 +17,6 @@ function renderWithStore(ui: React.ReactElement) {
 }
 
 describe('Registration Form', () => {
-
   it('renders all required input fields', () => {
     renderWithStore(<RegForm />)
     expect(screen.getByLabelText(/email/i)).toBeInTheDocument()

--- a/src/features/auth/components/tests/regForm.test.tsx
+++ b/src/features/auth/components/tests/regForm.test.tsx
@@ -1,15 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { Provider } from 'react-redux'
 import { RegForm } from '../regForm'
+import { store } from '../../../../store'
 import * as authService from '../../services/authService'
 
 describe('Registration Form', () => {
-  beforeEach(() => {
-    vi.restoreAllMocks()
-  })
+  const renderWithProvider = (ui: React.ReactElement) => {
+    return render(<Provider store={store}>{ui}</Provider>)
+  }
 
   it('renders all required input fields', () => {
-    render(<RegForm />)
+    renderWithProvider(<RegForm />)
     expect(screen.getByLabelText(/email/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/password/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/first name/i)).toBeInTheDocument()
@@ -22,7 +24,7 @@ describe('Registration Form', () => {
   })
 
   it('shows validation errors when submitting empty form', async () => {
-    render(<RegForm />)
+    renderWithProvider(<RegForm />)
     const button = screen.getByRole('button', { name: /register/i })
     fireEvent.click(button)
 
@@ -39,7 +41,7 @@ describe('Registration Form', () => {
         customer: { email: 'test@example.com', id: 'abc123' },
       })
 
-    render(<RegForm />)
+    renderWithProvider(<RegForm />)
 
     fireEvent.change(screen.getByLabelText(/email/i), {
       target: { value: 'test@example.com' },

--- a/src/features/auth/services/authService.ts
+++ b/src/features/auth/services/authService.ts
@@ -10,6 +10,16 @@ const API_SIGNUP_URL = `${API_BASE_URL}/${PROJECT_KEY}/customers`
 const API_TOKEN_URL = `${AUTH_BASE_URL}/oauth/${PROJECT_KEY}/customers/token`
 const API_ME_URL = `${API_BASE_URL}/${PROJECT_KEY}/me`
 
+export async function loginUser(email: string, password: string) {
+  const tokenData = await loginWithPassword(email, password)
+  const customer = await getCustomerData(tokenData.access_token)
+
+  return {
+    token: tokenData.access_token,
+    customer,
+  }
+}
+
 async function getClientAccessToken() {
   const response = await fetch(`${AUTH_BASE_URL}/oauth/token`, {
     method: 'POST',

--- a/src/store/local-storage.ts
+++ b/src/store/local-storage.ts
@@ -21,5 +21,3 @@ export const saveAuthState = (state: AuthState) => {
     console.warn('Failed to save auth state to localStorage:', err)
   }
 }
-
-

--- a/src/store/local-storage.ts
+++ b/src/store/local-storage.ts
@@ -1,6 +1,7 @@
 import type { AuthState } from './slices/auth-slice'
 
 const AUTH_STATE_KEY = 'auth'
+const AUTH_TOKEN_KEY = 'auth_token'
 
 export const loadAuthState = (): AuthState | undefined => {
   try {
@@ -19,5 +20,13 @@ export const saveAuthState = (state: AuthState) => {
     localStorage.setItem(AUTH_STATE_KEY, serializedState)
   } catch (err) {
     console.warn('Failed to save auth state to localStorage:', err)
+  }
+}
+
+export const clearAuthState = () => {
+  try {
+    localStorage.removeItem(AUTH_TOKEN_KEY)
+  } catch (err) {
+    console.warn('Failed to clear auth state to localStorage:', err)
   }
 }

--- a/src/store/local-storage.ts
+++ b/src/store/local-storage.ts
@@ -1,7 +1,6 @@
 import type { AuthState } from './slices/auth-slice'
 
 const AUTH_STATE_KEY = 'auth'
-const AUTH_TOKEN_KEY = 'auth_token'
 
 export const loadAuthState = (): AuthState | undefined => {
   try {
@@ -23,10 +22,4 @@ export const saveAuthState = (state: AuthState) => {
   }
 }
 
-export const clearAuthState = () => {
-  try {
-    localStorage.removeItem(AUTH_TOKEN_KEY)
-  } catch (err) {
-    console.warn('Failed to clear auth state to localStorage:', err)
-  }
-}
+

--- a/src/store/local-storage.ts
+++ b/src/store/local-storage.ts
@@ -1,8 +1,11 @@
 import type { AuthState } from './slices/auth-slice'
 
+const AUTH_STATE_KEY = 'auth'
+const AUTH_TOKEN_KEY = 'auth_token'
+
 export const loadAuthState = (): AuthState | undefined => {
   try {
-    const serializedState = localStorage.getItem('auth')
+    const serializedState = localStorage.getItem(AUTH_STATE_KEY)
     if (!serializedState) return undefined
     return JSON.parse(serializedState)
   } catch (err) {
@@ -14,8 +17,30 @@ export const loadAuthState = (): AuthState | undefined => {
 export const saveAuthState = (state: AuthState) => {
   try {
     const serializedState = JSON.stringify(state)
-    localStorage.setItem('auth', serializedState)
+    localStorage.setItem(AUTH_STATE_KEY, serializedState)
   } catch (err) {
     console.warn('Failed to save auth state to localStorage:', err)
   }
+}
+
+export const saveToken = (token: string) => {
+  try {
+    localStorage.setItem(AUTH_TOKEN_KEY, token)
+  } catch (err) {
+    console.warn('Failed to save token:', err)
+  }
+}
+
+export const getToken = (): string | null => {
+  try {
+    return localStorage.getItem(AUTH_TOKEN_KEY)
+  } catch (err) {
+    return null
+  }
+}
+
+export const removeToken = () => {
+  try {
+    localStorage.removeItem(AUTH_TOKEN_KEY)
+  } catch {}
 }

--- a/src/store/local-storage.ts
+++ b/src/store/local-storage.ts
@@ -1,7 +1,6 @@
 import type { AuthState } from './slices/auth-slice'
 
 const AUTH_STATE_KEY = 'auth'
-const AUTH_TOKEN_KEY = 'auth_token'
 
 export const loadAuthState = (): AuthState | undefined => {
   try {
@@ -21,26 +20,4 @@ export const saveAuthState = (state: AuthState) => {
   } catch (err) {
     console.warn('Failed to save auth state to localStorage:', err)
   }
-}
-
-export const saveToken = (token: string) => {
-  try {
-    localStorage.setItem(AUTH_TOKEN_KEY, token)
-  } catch (err) {
-    console.warn('Failed to save token:', err)
-  }
-}
-
-export const getToken = (): string | null => {
-  try {
-    return localStorage.getItem(AUTH_TOKEN_KEY)
-  } catch (err) {
-    return null
-  }
-}
-
-export const removeToken = () => {
-  try {
-    localStorage.removeItem(AUTH_TOKEN_KEY)
-  } catch {}
 }

--- a/src/store/slices/auth-slice.ts
+++ b/src/store/slices/auth-slice.ts
@@ -1,6 +1,10 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
 import { type CustomerType } from '../../types/customer'
-import { loadAuthState, saveAuthState } from '../local-storage.ts'
+import {
+  loadAuthState,
+  saveAuthState,
+  clearAuthState,
+} from '../local-storage.ts'
 
 export type AuthState = {
   isLoggedIn: boolean
@@ -47,6 +51,7 @@ const authSlice = createSlice({
       state.token = null
       state.status = 'idle'
       state.error = null
+      clearAuthState()
     },
   },
 })

--- a/src/store/slices/auth-slice.ts
+++ b/src/store/slices/auth-slice.ts
@@ -5,24 +5,28 @@ import { removeToken } from '../local-storage.ts'
 export type AuthState = {
   isLoggedIn: boolean
   customer: CustomerType | null
+  token : string | null
 }
 
 export const authInitialState: AuthState = {
   isLoggedIn: false,
   customer: null,
+  token: null
 }
 
 const authSlice = createSlice({
   name: 'auth',
   initialState: authInitialState,
   reducers: {
-    login(state, action: PayloadAction<CustomerType>) {
+    login(state, action: PayloadAction<{ customer: CustomerType; token: string}>) {
       state.isLoggedIn = true
-      state.customer = action.payload
+      state.customer = action.payload.customer
+      state.token = action.payload.token
     },
     logout(state) {
       state.isLoggedIn = false
       state.customer = null
+      state.token = null
       localStorage.removeItem('auth')
       removeToken()
     },

--- a/src/store/slices/auth-slice.ts
+++ b/src/store/slices/auth-slice.ts
@@ -1,55 +1,45 @@
-import { createSlice, createAsyncThunk, type PayloadAction } from '@reduxjs/toolkit'
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
 import { type CustomerType } from '../../types/customer'
-import { removeToken, loadAuthState, saveAuthState, saveToken } from '../local-storage.ts'
-import * as authService from '../../features/auth/services/authService.ts'
+import { loadAuthState, saveAuthState } from '../local-storage.ts'
 
 export type AuthState = {
   isLoggedIn: boolean
   customer: CustomerType | null
-  token : string | null
+  token: string | null
   status: 'idle' | 'loading' | 'succeeded' | 'failed'
   error: string | null
 }
 
-export const authInitialState: AuthState = 
-  loadAuthState() || {
-    isLoggedIn: false,
-    customer: null,
-    token: null,
-    status: 'idle',
-    error: null,
+export const authInitialState: AuthState = loadAuthState() || {
+  isLoggedIn: false,
+  customer: null,
+  token: null,
+  status: 'idle',
+  error: null,
 }
-
-export const loginAsync = createAsyncThunk(
-  'auth/loginAsync',
-  async (
-    { email, password }: { email: string; password: string },
-    { rejectWithValue }
-  ) => {
-    try {
-      const tokenData = await authService.loginWithPassword(email, password)
-      const customer = await authService.getCustomerData(tokenData.access_token)
-
-      return {
-        customer,
-        token: tokenData.access_token,
-      }
-    } catch (err: any) {
-      return rejectWithValue(err.message || 'Login failed')
-    }
-  }
-)
 
 const authSlice = createSlice({
   name: 'auth',
   initialState: authInitialState,
   reducers: {
-    login(state, action: PayloadAction<{ customer: CustomerType; token: string}>) {
+    loginStarted(state) {
+      state.status = 'loading'
+      state.error = null
+    },
+    login(
+      state,
+      action: PayloadAction<{ customer: CustomerType; token: string }>,
+    ) {
       state.isLoggedIn = true
       state.customer = action.payload.customer
       state.token = action.payload.token
-      saveAuthState(state)
-      saveToken(action.payload.token)
+      state.status = 'succeeded'
+      state.error = null
+      saveAuthState({ ...state, token: null })
+    },
+    loginFailed(state, action: PayloadAction<string>) {
+      state.status = 'failed'
+      state.error = action.payload
     },
     logout(state) {
       state.isLoggedIn = false
@@ -58,46 +48,9 @@ const authSlice = createSlice({
       state.status = 'idle'
       state.error = null
       localStorage.removeItem('auth')
-      removeToken()
     },
-  },
-  extraReducers: (builder) => {
-    builder
-      .addCase(loginAsync.pending, (state) => {
-        state.status = 'loading'
-      })
-      .addCase(loginAsync.fulfilled, (state, action) => {
-        state.status = 'succeeded'
-        state.isLoggedIn = true
-        state.customer = action.payload.customer
-        state.token = action.payload.token
-        state.error = null
-        saveAuthState(state)
-        saveToken(action.payload.token)
-      })
-      .addCase(loginAsync.rejected, (state, action) => {
-        state.status = 'failed'
-        state.error = action.payload as string
-      })
   },
 })
 
-export const verifyTokenAsync = createAsyncThunk(
-  'auth/verifyTokenAsync',
-  async (_, { getState, dispatch, rejectWithValue }) => {
-    const state = getState() as { auth: AuthState }
-
-    if (!state.auth.token) return rejectWithValue('No token available')
-
-    try {
-      const customer = await authService.getCustomerData(state.auth.token)
-      return { customer }
-    } catch (error: any) {
-      dispatch(logout())
-      return rejectWithValue('Invalid or expired token')
-    }
-  }
-)
-
-export const { login, logout } = authSlice.actions
+export const { loginStarted, login, loginFailed, logout } = authSlice.actions
 export default authSlice.reducer

--- a/src/store/slices/auth-slice.ts
+++ b/src/store/slices/auth-slice.ts
@@ -82,6 +82,22 @@ const authSlice = createSlice({
   },
 })
 
+export const verifyTokenAsync = createAsyncThunk(
+  'auth/verifyTokenAsync',
+  async (_, { getState, dispatch, rejectWithValue }) => {
+    const state = getState() as { auth: AuthState }
+
+    if (!state.auth.token) return rejectWithValue('No token available')
+
+    try {
+      const customer = await authService.getCustomerData(state.auth.token)
+      return { customer }
+    } catch (error: any) {
+      dispatch(logout())
+      return rejectWithValue('Invalid or expired token')
+    }
+  }
+)
 
 export const { login, logout } = authSlice.actions
 export default authSlice.reducer

--- a/src/store/slices/auth-slice.ts
+++ b/src/store/slices/auth-slice.ts
@@ -34,7 +34,6 @@ const authSlice = createSlice({
       state.token = action.payload.token
       state.status = 'succeeded'
       state.error = null
-
     },
     loginFailed(state, action: PayloadAction<string>) {
       state.status = 'failed'

--- a/src/store/slices/auth-slice.ts
+++ b/src/store/slices/auth-slice.ts
@@ -1,6 +1,6 @@
 import { createSlice, createAsyncThunk, type PayloadAction } from '@reduxjs/toolkit'
 import { type CustomerType } from '../../types/customer'
-import { removeToken } from '../local-storage.ts'
+import { removeToken, loadAuthState, saveAuthState, saveToken } from '../local-storage.ts'
 import * as authService from '../../features/auth/services/authService.ts'
 
 export type AuthState = {
@@ -11,12 +11,13 @@ export type AuthState = {
   error: string | null
 }
 
-export const authInitialState: AuthState = {
-  isLoggedIn: false,
-  customer: null,
-  token: null,
-  status: 'idle',
-  error: null,
+export const authInitialState: AuthState = 
+  loadAuthState() || {
+    isLoggedIn: false,
+    customer: null,
+    token: null,
+    status: 'idle',
+    error: null,
 }
 
 export const loginAsync = createAsyncThunk(
@@ -47,6 +48,8 @@ const authSlice = createSlice({
       state.isLoggedIn = true
       state.customer = action.payload.customer
       state.token = action.payload.token
+      saveAuthState(state)
+      saveToken(action.payload.token)
     },
     logout(state) {
       state.isLoggedIn = false
@@ -69,6 +72,8 @@ const authSlice = createSlice({
         state.customer = action.payload.customer
         state.token = action.payload.token
         state.error = null
+        saveAuthState(state)
+        saveToken(action.payload.token)
       })
       .addCase(loginAsync.rejected, (state, action) => {
         state.status = 'failed'

--- a/src/store/slices/auth-slice.ts
+++ b/src/store/slices/auth-slice.ts
@@ -1,5 +1,6 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
 import { type CustomerType } from '../../types/customer'
+import { removeToken } from '../local-storage.ts'
 
 export type AuthState = {
   isLoggedIn: boolean
@@ -23,6 +24,7 @@ const authSlice = createSlice({
       state.isLoggedIn = false
       state.customer = null
       localStorage.removeItem('auth')
+      removeToken()
     },
   },
 })

--- a/src/store/slices/auth-slice.ts
+++ b/src/store/slices/auth-slice.ts
@@ -1,10 +1,5 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
 import { type CustomerType } from '../../types/customer'
-import {
-  loadAuthState,
-  saveAuthState,
-  clearAuthState,
-} from '../local-storage.ts'
 
 export type AuthState = {
   isLoggedIn: boolean
@@ -14,7 +9,7 @@ export type AuthState = {
   error: string | null
 }
 
-export const authInitialState: AuthState = loadAuthState() || {
+export const authInitialState: AuthState = {
   isLoggedIn: false,
   customer: null,
   token: null,
@@ -39,7 +34,7 @@ const authSlice = createSlice({
       state.token = action.payload.token
       state.status = 'succeeded'
       state.error = null
-      saveAuthState({ ...state, token: null })
+
     },
     loginFailed(state, action: PayloadAction<string>) {
       state.status = 'failed'
@@ -51,7 +46,6 @@ const authSlice = createSlice({
       state.token = null
       state.status = 'idle'
       state.error = null
-      clearAuthState()
     },
   },
 })

--- a/src/store/slices/auth-slice.ts
+++ b/src/store/slices/auth-slice.ts
@@ -1,18 +1,43 @@
-import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
+import { createSlice, createAsyncThunk, type PayloadAction } from '@reduxjs/toolkit'
 import { type CustomerType } from '../../types/customer'
 import { removeToken } from '../local-storage.ts'
+import * as authService from '../../features/auth/services/authService.ts'
 
 export type AuthState = {
   isLoggedIn: boolean
   customer: CustomerType | null
   token : string | null
+  status: 'idle' | 'loading' | 'succeeded' | 'failed'
+  error: string | null
 }
 
 export const authInitialState: AuthState = {
   isLoggedIn: false,
   customer: null,
-  token: null
+  token: null,
+  status: 'idle',
+  error: null,
 }
+
+export const loginAsync = createAsyncThunk(
+  'auth/loginAsync',
+  async (
+    { email, password }: { email: string; password: string },
+    { rejectWithValue }
+  ) => {
+    try {
+      const tokenData = await authService.loginWithPassword(email, password)
+      const customer = await authService.getCustomerData(tokenData.access_token)
+
+      return {
+        customer,
+        token: tokenData.access_token,
+      }
+    } catch (err: any) {
+      return rejectWithValue(err.message || 'Login failed')
+    }
+  }
+)
 
 const authSlice = createSlice({
   name: 'auth',
@@ -27,11 +52,31 @@ const authSlice = createSlice({
       state.isLoggedIn = false
       state.customer = null
       state.token = null
+      state.status = 'idle'
+      state.error = null
       localStorage.removeItem('auth')
       removeToken()
     },
   },
+  extraReducers: (builder) => {
+    builder
+      .addCase(loginAsync.pending, (state) => {
+        state.status = 'loading'
+      })
+      .addCase(loginAsync.fulfilled, (state, action) => {
+        state.status = 'succeeded'
+        state.isLoggedIn = true
+        state.customer = action.payload.customer
+        state.token = action.payload.token
+        state.error = null
+      })
+      .addCase(loginAsync.rejected, (state, action) => {
+        state.status = 'failed'
+        state.error = action.payload as string
+      })
+  },
 })
+
 
 export const { login, logout } = authSlice.actions
 export default authSlice.reducer


### PR DESCRIPTION
## 📌 Summary

<!-- Provide a brief summary of the changes made in this PR -->
Refactor - of  Obtain the authentication token securely after a successful login attempt by sending a request to the token endpoint (e.g., https://auth.europe-west1.gcp.commercetools.com/oauth/project_key/customers/token), allowing for seamless user authentication across the application, but do not save it.
![loginSuccess](https://github.com/user-attachments/assets/68d6f326-ae1f-434c-a4ae-183e7742b0ff)

## 🔗 Trello Task Link

<!-- Add a link to the Trello card this PR addresses -->

[Trello Card](https://trello.com/c/5njLRwih/25-rss-ecomm-207-handle-authentication-token)

## 🛠️ Proposed Changes

<!-- List the main changes made -->
-The authentication token is obtained from the token endpoint after a successful login attempt.
-The token is used for subsequent requests that require authentication.
-

## 💡 Rationale

<!-- Explain the reason for the changes and the problem it solves -->
Token provides unique  user authentication and secure the info
## ✅ Checklist

- [ ] Code follows the project’s style guidelines
- [ ] Lint and tests pass (`npm run lint`, `npm run format`, `npm run test`)
- [ ] I’ve added/updated relevant documentation
- [ ] I’ve added/updated tests where applicable
- [ ] This PR includes only one logical change (no mix of concerns)
