### PR TITLE
RSS-ECOMM-4_01: Add "Add to Cart" Button on Product Cards

### DIFF
--- a/src/features/catalog/components/product-card.tsx
+++ b/src/features/catalog/components/product-card.tsx
@@ -1,6 +1,8 @@
-import type { DessertProduct } from '../../../types/dessert-product'
 import React from 'react'
 import { Link } from 'react-router-dom'
+import type { DessertProduct } from '../../../types/dessert-product'
+import { useAppSelector } from '../../../store/hooks'
+import { selectCartItems } from '../../../store/slices/cart-slice'
 
 type ProductCardProps = {
   product: DessertProduct
@@ -12,6 +14,9 @@ const ProductCard: React.FC<ProductCardProps> = ({ product, locale }) => {
   const name = product.name[locale]
   const description = product.description[locale]
   const slug = product.slug[locale]
+
+  const cartItems = useAppSelector(selectCartItems)
+  const isInCart = cartItems.includes(slug)
 
   const priceObj = product.masterVariant.prices?.[0]?.value
   const discounted = product.masterVariant.prices?.[0]?.discounted?.value
@@ -34,8 +39,8 @@ const ProductCard: React.FC<ProductCardProps> = ({ product, locale }) => {
       : null
 
   return (
-    <Link to={`/product/${slug}`} className="block h-full">
-      <div className="flex flex-col justify-between h-full bg-white border-transparent rounded-xl shadow-md p-4 transition-all duration-300 transform hover:shadow-xl hover:scale-105 hover:bg-gray-50 cursor-pointer">
+    <div className="flex flex-col items-center justify-between h-full bg-white border-transparent rounded-xl shadow-md p-4 transition-all duration-300 transform hover:shadow-xl hover:scale-105 hover:bg-gray-50">
+      <Link to={`/product/${slug}`} className="flex flex-col h-full">
         {imageUrl && (
           <img
             src={imageUrl}
@@ -48,7 +53,7 @@ const ProductCard: React.FC<ProductCardProps> = ({ product, locale }) => {
           <p className="text-sm text-gray-600 mb-2">{description}</p>
         </div>
 
-        <div className="mt-2">
+        <div className="mt-2 mb-3">
           {discountedPrice ? (
             <div>
               <p className="text-sm text-gray-500 line-through">
@@ -69,8 +74,16 @@ const ProductCard: React.FC<ProductCardProps> = ({ product, locale }) => {
             </p>
           )}
         </div>
-      </div>
-    </Link>
+      </Link>
+
+      <button
+        className={`flex items-center justify-center w-1/2 cursor-pointer uppercase mt-2 py-3 px-2 rounded-full text-sm bg-[#f7ebdd] hover:bg-[#e6d3bd] hover:[#3c2c21] font-medium transition`}
+        disabled={isInCart}
+        aria-label="Add to cart"
+      >
+        {isInCart ? 'In Cart' : 'Add to Cart'}
+      </button>
+    </div>
   )
 }
 

--- a/src/pages/tests/catalog-page.test.tsx
+++ b/src/pages/tests/catalog-page.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from 'react-router-dom'
 import CatalogPage from '../catalog-page'
 import * as hooks from '../../store/hooks'
 import * as catalogSlice from '../../store/slices/catalog-slice'
+import * as cartSlice from '../../store/slices/cart-slice'
 
 const mockProducts = [
   {
@@ -38,7 +39,7 @@ vi.mock('../../store/hooks', async () => {
   }
 })
 
-vi.mock('../store/slices/catalog-slice', async () => {
+vi.mock('../../store/slices/catalog-slice', async () => {
   const actual = await vi.importActual<
     typeof import('../../store/slices/catalog-slice')
   >('../../store/slices/catalog-slice')
@@ -61,6 +62,7 @@ describe('CatalogPage', () => {
       if (selectorFn === catalogSlice.selectCatalogProducts) return []
       if (selectorFn === catalogSlice.selectCatalogLoading) return false
       if (selectorFn === catalogSlice.selectCatalogError) return null
+      if (selectorFn === cartSlice.selectCartItems) return []
     })
 
     render(
@@ -77,6 +79,7 @@ describe('CatalogPage', () => {
       if (selectorFn === catalogSlice.selectCatalogProducts) return []
       if (selectorFn === catalogSlice.selectCatalogLoading) return true
       if (selectorFn === catalogSlice.selectCatalogError) return null
+      if (selectorFn === cartSlice.selectCartItems) return []
     })
 
     render(
@@ -93,6 +96,7 @@ describe('CatalogPage', () => {
       if (selectorFn === catalogSlice.selectCatalogLoading) return false
       if (selectorFn === catalogSlice.selectCatalogError)
         return 'Something went wrong'
+      if (selectorFn === cartSlice.selectCartItems) return []
     })
 
     render(
@@ -103,11 +107,12 @@ describe('CatalogPage', () => {
     expect(screen.getByText(/error: something went wrong/i)).toBeInTheDocument()
   })
 
-  it('renders products', () => {
+  it('renders products with enabled Add to Cart buttons', () => {
     ;(hooks.useAppSelector as Mock).mockImplementation((selectorFn) => {
       if (selectorFn === catalogSlice.selectCatalogProducts) return mockProducts
       if (selectorFn === catalogSlice.selectCatalogLoading) return false
       if (selectorFn === catalogSlice.selectCatalogError) return null
+      if (selectorFn === cartSlice.selectCartItems) return []
     })
 
     render(
@@ -118,7 +123,32 @@ describe('CatalogPage', () => {
 
     expect(screen.getByText('Apple Zefir')).toBeInTheDocument()
     expect(screen.getByText('Cranberry Marshmallow')).toBeInTheDocument()
-    expect(screen.getByAltText('Apple Zefir')).toBeInTheDocument()
-    expect(screen.getByAltText('Cranberry Marshmallow')).toBeInTheDocument()
+    expect(
+      screen.getAllByRole('button', { name: /add to cart/i }),
+    ).toHaveLength(2)
+    screen
+      .getAllByRole('button', { name: /add to cart/i })
+      .forEach((btn) => expect(btn).toBeEnabled())
+  })
+
+  it('disables Add to Cart button for product in cart', () => {
+    ;(hooks.useAppSelector as Mock).mockImplementation((selectorFn) => {
+      if (selectorFn === catalogSlice.selectCatalogProducts) return mockProducts
+      if (selectorFn === catalogSlice.selectCatalogLoading) return false
+      if (selectorFn === catalogSlice.selectCatalogError) return null
+      if (selectorFn === cartSlice.selectCartItems) return ['apple-zefir']
+    })
+
+    render(
+      <MemoryRouter>
+        <CatalogPage />
+      </MemoryRouter>,
+    )
+
+    const buttons = screen.getAllByRole('button', { name: /add to cart/i })
+
+    expect(buttons[0]).toBeDisabled()
+
+    expect(buttons[1]).toBeEnabled()
   })
 })

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2,6 +2,7 @@ import { configureStore } from '@reduxjs/toolkit'
 import authReducer, { authInitialState } from './slices/auth-slice'
 import catalogReducer from './slices/catalog-slice'
 import productReducer from './slices/product-slice'
+import cartReducer from './slices/cart-slice'
 import { loadAuthState, saveAuthState } from './local-storage'
 
 const preloadedAuthState = loadAuthState() ?? authInitialState
@@ -11,6 +12,7 @@ export const store = configureStore({
     auth: authReducer,
     catalog: catalogReducer,
     product: productReducer,
+    cart: cartReducer,
   },
   preloadedState: {
     auth: preloadedAuthState,

--- a/src/store/slices/cart-slice.ts
+++ b/src/store/slices/cart-slice.ts
@@ -1,0 +1,34 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
+import type { RootState } from '../index'
+
+type CartState = {
+  items: string[]
+}
+
+const initialState: CartState = {
+  items: [],
+}
+
+const cartSlice = createSlice({
+  name: 'cart',
+  initialState,
+  reducers: {
+    addToCart: (state, action: PayloadAction<string>) => {
+      if (!state.items.includes(action.payload)) {
+        state.items.push(action.payload)
+      }
+    },
+    removeFromCart: (state, action: PayloadAction<string>) => {
+      state.items = state.items.filter((id) => id !== action.payload)
+    },
+    clearCart: (state) => {
+      state.items = []
+    },
+  },
+})
+
+export const { addToCart, removeFromCart, clearCart } = cartSlice.actions
+
+export const selectCartItems = (state: RootState) => state.cart.items
+
+export default cartSlice.reducer

--- a/src/types/cart.ts
+++ b/src/types/cart.ts
@@ -1,0 +1,17 @@
+import type { Address } from './customer'
+import type { DessertProduct } from './dessert-product'
+
+export type Cart = {
+  id: string
+  version: number
+  createdAt: string
+  lineItems: DessertProduct[]
+  cartState: 'Active' | 'Merged' | 'Ordered' | 'Frozen'
+  totalPrice: {
+    type: 'centPrecision'
+    currencyCode: string
+    centAmount: number
+    fractionDigits: number
+  }
+  itemShippingAddresses: Address[]
+}


### PR DESCRIPTION
## 🔗 Trello Task Link

[Trello Card](https://trello.com/c/DeqspzFC)

## 🛠️ Proposed Changes

- Added an "Add to Cart"  button to each product card (`ProductCard` component)
- The button is conditionally disabled if the product is already in the cart
- Styled the button for visual clarity and intuitive user experience (positioned below the product details)
- Utilized `selectCartItems` from `cart-slice` to determine cart state
- Updated the `catalog-page.test.tsx` test suite:
  - Mocked `selectCartItems` to avoid runtime errors
  - Verified rendering of the "Add to Cart" button
  - Added a test to check that the button is disabled for items already in the cart

## 💡 Rationale

To align the UI with standard eCommerce practices and streamline the user’s shopping experience, each product card now includes an "Add to Cart" button. While functionality is not implemented at this stage, the visual cue enhances usability and sets the groundwork for cart interaction. Disabling the button for items already in the cart prevents duplicate additions and provides feedback to the user. Test coverage was updated accordingly to ensure consistent behavior and prevent regressions.

## ✅ Checklist

- [x] Code follows the project’s style guidelines
- [x] Lint and tests pass (`npm run lint`, `npm run format`, `npm run test`)
- [x] I’ve added/updated relevant documentation
- [x] I’ve added/updated tests where applicable
- [x] This PR includes only one logical change (no mix of concerns)
